### PR TITLE
Allows per-store configuration

### DIFF
--- a/src/app/code/community/Bitbull/Satispay/etc/system.xml
+++ b/src/app/code/community/Bitbull/Satispay/etc/system.xml
@@ -18,7 +18,7 @@
                             <sort_order>1</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </active>
                         <title translate="label">
                             <label>Title</label>
@@ -26,7 +26,7 @@
                             <sort_order>2</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </title>
                         <instructions translate="label">
                             <label>Instructions</label>
@@ -34,7 +34,7 @@
                             <sort_order>3</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </instructions>
                         <staging translate="label">
                             <label>Staging Mode</label>
@@ -43,7 +43,7 @@
                             <sort_order>4</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </staging>
                         <security_token translate="label">
                             <label>Security Token</label>
@@ -51,7 +51,7 @@
                             <sort_order>5</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </security_token>
                         <default_country_code translate="label">
                             <label>Default Country Code</label>
@@ -60,7 +60,7 @@
                             <sort_order>6</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                         </default_country_code>
                         <sort_order translate="label">
                             <label>Sort Order</label>
@@ -68,7 +68,7 @@
                             <sort_order>7</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                             <frontend_class>validate-number</frontend_class>
                         </sort_order>
                         <debug translate="label comment">
@@ -79,7 +79,7 @@
                             <sort_order>110</sort_order>
                             <show_in_default>1</show_in_default>
                             <show_in_website>1</show_in_website>
-                            <show_in_store>0</show_in_store>
+                            <show_in_store>1</show_in_store>
                             <depends><active>1</active></depends>
                         </debug>
                     </fields>


### PR DESCRIPTION
As the title says, this allows one to enable or disable the payment method for each single store view, as well as setting specific titles, texts and so on.
I'm not so sure about the "staging", "security_token" and "debug" fields (whether it makes sense to have these configurable per-store as well), but while I was at it I set these to the store view level as well.