### PR TITLE
Fixes the initial state of new orders

### DIFF
--- a/src/app/code/community/Bitbull/Satispay/Model/Payment.php
+++ b/src/app/code/community/Bitbull/Satispay/Model/Payment.php
@@ -133,6 +133,13 @@ class Bitbull_Satispay_Model_Payment extends Mage_Payment_Model_Method_Abstract
         $session->setOrderId($orderId)
             ->setCurrency($currency)
             ->setAmount(round($amount * 100));
+        
+        $stateObject->setState(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
+        
+        //It would be better to ask Magento for the default status of the "pending_payment" state,
+        //but as other parts of the module explicitly check the status against this constant, then
+        //I think it's fine to leave this here.
+        $stateObject->setStatus(Mage_Sales_Model_Order::STATE_PENDING_PAYMENT);
 
         return $this;
     }

--- a/src/app/code/community/Bitbull/Satispay/etc/config.xml
+++ b/src/app/code/community/Bitbull/Satispay/etc/config.xml
@@ -72,7 +72,6 @@
         <payment>
             <satispay>
                 <title>Pay with Satispay</title>
-                <order_status>pending_payment</order_status>
                 <payment_action>sale</payment_action>
                 <model>satispay/payment</model>
                 <default_country_code>+39</default_country_code>


### PR DESCRIPTION
Before this PR new orders are created in the "new" state and "pending_payment" status, which is not a standard combination (see Mage_Sales_Model_Order_Payment::place(), line 333 in Magento 1.7.0.2).

This PR moves the logic inside the initialize() method and sets both the state and status, so that new orders can be created with a standard pair of state and status.

(Sorry for the merge in the PR, I goofed up...)